### PR TITLE
Fix multiple bugs in run.py and setup_regression_model.py

### DIFF
--- a/setup_regression_model.py
+++ b/setup_regression_model.py
@@ -1,5 +1,6 @@
 import os
 import pandas as pd
+import numpy as np
 from sklearn.linear_model import LogisticRegression
 from openai import OpenAI
 from dotenv import load_dotenv


### PR DESCRIPTION
- Add missing numpy import in setup_regression_model.py
- Fix wrong error messages: medrxiv/biorxiv errors were incorrectly labeled as chemrxiv
- Replace os.system() with os.remove() for secure file deletion
- Replace bare except clauses with specific exception types
- Remove unused MIMEText object and n_titles variable
- Add bounds check for response.choices before accessing index 0
- Fix return type annotations for scrape functions (now correctly show tuple returns)
- Replace fragile string-based date formatting with strftime()
- Fix misleading cutoff display in email body (show actual value used)