### PR TITLE
Add optional second email recipient for daily paper updates

### DIFF
--- a/.github/workflows/submit_jobs.yml
+++ b/.github/workflows/submit_jobs.yml
@@ -33,5 +33,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           MY_EMAIL: ${{ secrets.MY_EMAIL }}
           MY_PW: ${{ secrets.MY_PW }}
+          MY_EMAIL_2: ${{ secrets.MY_EMAIL_2 }}
         run: |
           python -c "from run import main; main(1, test_mode=False)"

--- a/.github/workflows/test_job_submission.yml
+++ b/.github/workflows/test_job_submission.yml
@@ -31,5 +31,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           MY_EMAIL: ${{ secrets.MY_EMAIL }}
           MY_PW: ${{ secrets.MY_PW }}
+          MY_EMAIL_2: ${{ secrets.MY_EMAIL_2 }}
         run: |
           python -c "from run import main; main(1, test_mode=True)"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repo contains the code I use for fetching new papers every morning that mig
     * MY_EMAIL: Your email
     * MY_PW: An app password assigned by your email client (not your actual email password!)
     * OPENAI_API_KEY: The API Key for OpenAI used to calculate embeddings and generate summaries.
+    * MY_EMAIL_2 (optional): A second email address to receive the daily paper updates. If configured, both email addresses will receive the notifications.
 3. Optional: setup your logistic regression model using setup_regression_model.py (TODO)
 
 #### TODO

--- a/run.py
+++ b/run.py
@@ -301,9 +301,14 @@ def main(n_days: int, test_mode: bool = False, cutoff: float = 3.5) -> None:
 
     df = embed_papers(client, data, test_mode=test_mode, cutoff=cutoff / 10)
 
+    # Build recipient list - include second email if configured
+    recipients = [os.environ.get("MY_EMAIL")]
+    if os.environ.get("MY_EMAIL_2"):
+        recipients.append(os.environ.get("MY_EMAIL_2"))
+
     message = MIMEMultipart()
     message["From"] = os.environ.get("MY_EMAIL")
-    message["To"] = os.environ.get("MY_EMAIL")
+    message["To"] = ", ".join(recipients)
     message["Subject"] = f"Papers {datetime.now()}"
 
     n_arxiv = len(data_arxiv["Title"])
@@ -340,5 +345,5 @@ def main(n_days: int, test_mode: bool = False, cutoff: float = 3.5) -> None:
     with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
         server.login(os.environ.get("MY_EMAIL"), os.environ.get("MY_PW"))
         server.sendmail(
-            os.environ.get("MY_EMAIL"), os.environ.get("MY_EMAIL"), message.as_string()
+            os.environ.get("MY_EMAIL"), recipients, message.as_string()
         )


### PR DESCRIPTION
Support sending emails to a second address via MY_EMAIL_2 secret. When configured, both email addresses receive the daily notifications.