### PR TITLE
Add rate limiting delays to avoid TPM limit violations

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@ import contextlib
 import json
 import os
 import smtplib
+import time
 from datetime import datetime, timedelta
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -159,6 +160,9 @@ def classify_papers(
                     relevant.append(paper)
             if test_mode and len(relevant) >= 5:
                 return relevant[:5]
+            # Stagger batches to avoid hitting the TPM rate limit
+            if i + batch_size < len(candidates):
+                await asyncio.sleep(5)
         return relevant
 
     return asyncio.run(_classify_all())
@@ -532,6 +536,8 @@ def main(n_days: int, test_mode: bool = False) -> None:
         journal = paper["Journal"]
         link = paper["Link"]
         authors = paper["Authors"]
+        # Stagger summarization calls to avoid hitting the TPM rate limit
+        time.sleep(2)
         summary = summarize_abstract(client, title, abstract)
         # Add link to title if available
         if link:


### PR DESCRIPTION
## Summary
Added delays to the paper classification and summarization pipeline to prevent hitting OpenAI's tokens-per-minute (TPM) rate limits during batch processing.

## Key Changes
- Added `import time` to support synchronous sleep calls
- Added 5-second delay between classification batches when processing multiple candidates to stagger API requests
- Added 2-second delay before each summarization call to avoid rapid successive requests

## Implementation Details
- The batch stagger delay is only applied when there are more candidates to process (`if i + batch_size < len(candidates)`), avoiding unnecessary delays on the final batch
- Used `asyncio.sleep()` for the async classification context and `time.sleep()` for the synchronous summarization context to maintain consistency with each function's execution model
- These delays are conservative measures to ensure stable API usage without overwhelming rate limits during high-volume paper processing

https://claude.ai/code/session_011FjTgpXmP5TShFLxYRGSje