### PR TITLE
Fix unsupported max_tokens parameter for gpt-5-nano model

### DIFF
--- a/run.py
+++ b/run.py
@@ -96,7 +96,7 @@ async def classify_paper(
                 ),
             },
         ],
-        max_tokens=10,
+        max_completion_tokens=10,
     )
     if not response.choices:
         return False


### PR DESCRIPTION
Replace max_tokens with max_completion_tokens in the classify_paper
function, as gpt-5-nano requires max_completion_tokens instead.

https://claude.ai/code/session_01C711LcF6JsoGjTmxcw1Pgd