### PR TITLE
Fix incorrect keyword argument begin_date -> start_date for paperscraper functions

### DIFF
--- a/run.py
+++ b/run.py
@@ -340,7 +340,7 @@ def scrape_biorxiv(n_days: int) -> tuple[dict[str, list], list[str]]:
     error_msgs = []
     try:
         chemrxiv(
-            begin_date=format_date(start_rxivs, "-"),
+            start_date=format_date(start_rxivs, "-"),
             end_date=format_date(end_rxivs, "-"),
             save_path="chemrxiv.jsonl",
         )
@@ -348,7 +348,7 @@ def scrape_biorxiv(n_days: int) -> tuple[dict[str, list], list[str]]:
         error_msgs.append(f"Chemrxiv scrape failed with error {e}. Continuing...")
     try:
         medrxiv(
-            begin_date=format_date(start_rxivs, "-"),
+            start_date=format_date(start_rxivs, "-"),
             end_date=format_date(end_rxivs, "-"),
             save_path="medrxiv.jsonl",
         )
@@ -356,7 +356,7 @@ def scrape_biorxiv(n_days: int) -> tuple[dict[str, list], list[str]]:
         error_msgs.append(f"Medrxiv scrape failed with error {e}. Continuing...")
     try:
         biorxiv(
-            begin_date=format_date(start_rxivs, "-"),
+            start_date=format_date(start_rxivs, "-"),
             end_date=format_date(end_rxivs, "-"),
             save_path="biorxiv.jsonl",
         )


### PR DESCRIPTION
The biorxiv(), medrxiv(), and chemrxiv() functions from paperscraper.get_dumps
accept start_date (not begin_date) as the parameter for the start of the date
range. All three call sites in scrape_biorxiv() are updated accordingly.

https://claude.ai/code/session_01FGdNXBKYBtvpnT8XGTRE7E