### PR TITLE
Replace arxivscraper with official arxiv library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arxivscraper
+arxiv
 markdown
 openai
 paperscraper


### PR DESCRIPTION
## Summary
Migrated from the `arxivscraper` library to the official `arxiv` Python client library for improved reliability and maintainability.

## Key Changes
- Replaced `arxivscraper.Scraper` with `arxiv.Client` and `arxiv.Search` for querying arXiv papers
- Updated date format from `YYYY-MM-DD` to `YYYYMMDD` to match the official arxiv API requirements
- Refactored query construction to use the official arxiv query syntax: `cat:{category} AND submittedDate:[{start}0000 TO {end}2359]`
- Updated paper data extraction to use official `arxiv.Result` object attributes:
  - `paper["title"]` → `result.title`
  - `paper["abstract"]` → `result.summary`
  - `paper["id"]` → `result.entry_id` (now directly provides full URL)
  - `paper["authors"]` → `result.authors` (now a list of author objects with `.name` attribute)
- Simplified author handling by directly joining author names from the result object
- Removed error handling for `None`, `1`, or empty results (official library handles these cases)
- Added explicit sorting by submission date in descending order with `max_results=1000` limit

## Implementation Details
The official `arxiv` library provides a more robust and actively maintained interface compared to the community-maintained `arxivscraper`. The new implementation uses the library's native query syntax and result objects, eliminating the need for manual ID construction and author list parsing.

https://claude.ai/code/session_018dkHfy5H7dSzehy7EL4Amr