### PR TITLE
Add model parameter to support multiple OpenAI models

### DIFF
--- a/.github/workflows/weekly_gpt4o_mini.yml
+++ b/.github/workflows/weekly_gpt4o_mini.yml
@@ -1,0 +1,41 @@
+name: Run weekly fetch with gpt-4o-mini
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  run-clock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install libxml build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev libxslt-dev
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run fetching and classification (previous week, gpt-4o-mini)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MY_EMAIL: ${{ secrets.MY_EMAIL }}
+          MY_PW: ${{ secrets.MY_PW }}
+          MY_EMAIL_2: ${{ secrets.MY_EMAIL_2 }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python -c "from run import main; main(7, test_mode=False, model='gpt-4o-mini')"


### PR DESCRIPTION
## Summary
This PR adds support for using different OpenAI models throughout the paper classification and summarization pipeline. Previously, the code was hardcoded to use `gpt-5-nano`, but now it accepts a configurable model parameter that can be passed through the entire workflow.

## Key Changes
- Added `model` parameter to `main()`, `classify_papers()`, `classify_paper()`, and `summarize_abstract()` functions with `gpt-5-nano` as the default
- Implemented conditional logic in `classify_paper()` to handle API differences between models:
  - `gpt-4o-mini` uses `max_tokens` parameter
  - `gpt-5-nano` uses `max_completion_tokens` parameter
- Updated all function calls to pass the model parameter through the call chain
- Added a new GitHub Actions workflow (`weekly_gpt4o_mini.yml`) that runs the weekly fetch using `gpt-4o-mini` instead of the default model
- Updated docstrings to reflect the new model parameter and its purpose

## Notable Implementation Details
- The token parameter handling uses a conditional dictionary (`token_kwarg`) to accommodate API differences between OpenAI models
- The workflow is triggered manually via `workflow_dispatch` and sets up all necessary dependencies and environment variables
- The default model remains `gpt-5-nano` to maintain backward compatibility with existing code

https://claude.ai/code/session_01U79Asnwubr4FhNRkgxyDcs