### PR TITLE
Add retry logic and rate limit handling for arXiv API requests

### DIFF
--- a/run.py
+++ b/run.py
@@ -148,7 +148,7 @@ def scrape_arxiv(
     start = (datetime.now() - timedelta(days=n_days + 1)).strftime("%Y%m%d")
     end = (datetime.now() - timedelta(days=1)).strftime("%Y%m%d")
 
-    client = arxiv.Client()
+    client = arxiv.Client(delay_seconds=5.0, num_retries=5)
     for cat in categories:
         query = f"cat:{cat} AND submittedDate:[{start}0000 TO {end}2359]"
         search = arxiv.Search(
@@ -157,13 +157,28 @@ def scrape_arxiv(
             sort_by=arxiv.SortCriterion.SubmittedDate,
             sort_order=arxiv.SortOrder.Descending,
         )
-        for result in client.results(search):
-            data["Title"].append(result.title)
-            data["Abstract"].append(result.summary.replace("\n", " "))
-            data["Journal"].append("arXiv")
-            data["Link"].append(result.entry_id)
-            authors = ", ".join(author.name for author in result.authors)
-            data["Authors"].append(authors if authors else "Authors not available")
+        retries = 0
+        max_retries = 5
+        while retries <= max_retries:
+            try:
+                for result in client.results(search):
+                    data["Title"].append(result.title)
+                    data["Abstract"].append(result.summary.replace("\n", " "))
+                    data["Journal"].append("arXiv")
+                    data["Link"].append(result.entry_id)
+                    authors = ", ".join(author.name for author in result.authors)
+                    data["Authors"].append(authors if authors else "Authors not available")
+                break
+            except arxiv.HTTPError as e:
+                if e.status == 429 and retries < max_retries:
+                    wait = 60 * (2 ** retries)
+                    print(f"arXiv rate limit hit for category {cat}, waiting {wait}s before retry {retries + 1}/{max_retries}...")
+                    time.sleep(wait)
+                    retries += 1
+                else:
+                    raise
+        if cat != categories[-1]:
+            time.sleep(10)
     return data, ""
 
 


### PR DESCRIPTION
## Summary
Enhanced the arXiv scraping functionality with robust error handling and rate limit management to improve reliability when fetching papers from the arXiv API.

## Key Changes
- **Client configuration**: Initialize `arxiv.Client` with `delay_seconds=5.0` and `num_retries=5` parameters for built-in request throttling
- **Retry mechanism**: Implemented exponential backoff retry logic that catches `arxiv.HTTPError` with status 429 (rate limit) and automatically retries up to 5 times
- **Backoff strategy**: Uses exponential backoff formula `60 * (2 ** retries)` to progressively increase wait time between retries (60s, 120s, 240s, etc.)
- **Inter-category delay**: Added 10-second delay between category requests to further reduce rate limit pressure
- **User feedback**: Added informative logging messages when rate limits are encountered, showing wait duration and retry progress

## Implementation Details
- The retry logic wraps the result iteration in a try-except block that specifically handles `arxiv.HTTPError` exceptions
- Only HTTP 429 errors trigger automatic retries; other errors are re-raised immediately
- The loop breaks successfully once results are processed without errors
- Delays are applied between category iterations to space out API requests

https://claude.ai/code/session_01DS3KaMk7YLdrJbuMhFWPqC